### PR TITLE
Added missing requirement for testing to `requirements_test.txt`

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,3 @@
 numpy>=1.18.4
 pytest-xdist
+frozendict


### PR DESCRIPTION
Added missing requirement `frozendict`, which is needed in /tests/optimizers_test.py.

